### PR TITLE
Backwards Compatibility Patch for fixed compilation error for 'undefined ngx_http_null_variable'

### DIFF
--- a/ipscrub/src/ngx_ipscrub_module.c
+++ b/ipscrub/src/ngx_ipscrub_module.c
@@ -24,7 +24,7 @@ static ngx_http_variable_t ngx_http_ipscrub_vars[] = {
     {ngx_string("remote_addr_ipscrub"), NULL, ngx_http_variable_remote_addr_ipscrub, 0, 0, 0},
     {ngx_string("ipscrub_hash_debug"), NULL, ngx_http_variable_remote_addr_ipscrub_debug, 0, 0, 0},
     {ngx_string("ipscrub_salted_hash_debug"), NULL, ngx_http_variable_ipscrub_salted_hash_debug, 0, 0, 0},
-    ngx_http_null_variable};
+    {ngx_null_string, NULL, NULL, 0, 0, 0 }};
 
 
 static ngx_command_t  ngx_ipscrub_commands[] = {


### PR DESCRIPTION
## The Problem
When compiling this module for `nginx/1.12.2`, I hit this compilation error:

```
cc -c -fPIC -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g  -I src/core -I src/event -I src/event/modules -I src/os/unix -I objs -I src/http -I src/http/modules \
		-o objs/addon/src/ngx_ipscrub_module.o \
		../ipscrub/ipscrub/src/ngx_ipscrub_module.c
../ipscrub/ipscrub/src/ngx_ipscrub_module.c:27:5: error: ‘ngx_http_null_variable’ undeclared here (not in a function)
     ngx_http_null_variable};
```

## The Fix
Replace the reference to the historically undefined macro with an explicit decleration here.

## The Result
This module now compiles successfully for the most recent nginx version as well as version 1.12.2. This should fix more versions than just 1.12.2, but that's just the one I can conveniently test. 

## Background Info
After further investigation, it looks like `ngx_http_null_variable` was introduced in nginx v1.13 as a convenience macro for `{ngx_null_string, NULL, NULL, 0, 0, 0 }`. 