### PR TITLE
ensure there is no NULL char among random data

### DIFF
--- a/ipscrub/src/ngx_ipscrub_support.c
+++ b/ipscrub/src/ngx_ipscrub_support.c
@@ -58,7 +58,9 @@ ngx_int_t randbytes(u_char *out, int num_bytes) {
     return NGX_ERROR;
   }
 
-  arc4random_buf(out, num_bytes);
+  do{
+    arc4random_buf(out, num_bytes);
+  }while(ngx_strlen(out)<num_bytes); // ensure there is no \0 char among random data
 
   return NGX_OK;
 }


### PR DESCRIPTION
This random data is later used as part of input for ngx_crypt function, which expects a zero-terminated string. If the string contains a zero character, then rest of string is ignored, and the seed is effectively truncated. Good that the seed is at the end of the string. :) I believe it's better to exclude strings containing zero character from possible outputs of this function, rather than truncate everything after it.